### PR TITLE
Issue #21 Term Tally Table

### DIFF
--- a/formatter.R
+++ b/formatter.R
@@ -67,7 +67,7 @@ if(sum(!is.na(text_terms)) > 0) {
   text_terms_pretty <- text_terms
   for (group in 1:length(text_terms)){
     for (term in 1:length(text_terms[[group]])){
-      prettier_term <- make_text_terms_pretty((text_terms[[group]][term]))
+      prettier_term <- make_text_terms_pretty(text_terms[[group]][term])
       text_terms_pretty[[group]][term] <- prettier_term
     }
   }

--- a/formatter.R
+++ b/formatter.R
@@ -195,19 +195,11 @@ for (i in file_list) {
       
     }
   
-  # add in a note between this table and the term tally table
-  note <- c(
-    "Explain table",
-    "Note: Caveat"
-    )
-  writeData(wb, 
-            sheet = summary_sheet_name, 
-            x = note, 
-            startRow = table_start_row, 
-            startCol = 1)
   
   # increment start row to allow next table to be further down on page
-  table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
+  table_start_row <- add_term_tally_table_header(wb, 
+                                                 sheet = summary_sheet_name,
+                                                 content_start_row = table_start_row)
   
   # repeat for term tally tables for the same sheets
   for (term_columns in database_name) {

--- a/formatter.R
+++ b/formatter.R
@@ -199,7 +199,7 @@ for (i in file_list) {
       
     }
   
-  # checking that there are text terms in search strategy
+  # create group and text term tally tables if there are text terms in search strategy and this is set to do so in params
   if(sum(!is.na(text_terms)) > 0 && include_term_tally_table == "yes"){
     
     # header for the group/term tally table
@@ -209,83 +209,70 @@ for (i in file_list) {
                                                   text_to_add = "term_tally_table_heading"
                                                   )
     
-    # create and add the group tally tables underneath the header
-    for (group_columns in database_name) {
-      # create term tally table for unsampled data and apply make_text_terms_pretty function
-      group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
-                                                             cols_to_use = "group_columns")
+    # create unsampled group tally table
+    group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
+                                                           cols_to_use = "group_columns")
+    
+    #add headers for sampled/unsampled tables if needed
+    if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+      table_start_row <- add_text_to_summary_sheets(wb, 
+                                                    sheet = summary_sheet_name,
+                                                    content_start_row = table_start_row,
+                                                    text_to_add = "sampled_table_headers")
+    }
       
-      #add headers for sampled/unsampled tables where sampling took place
-      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        table_start_row <- add_text_to_summary_sheets(wb, 
-                                                      sheet = summary_sheet_name,
-                                                      content_start_row = table_start_row,
-                                                      text_to_add = "sampled_table_headers")
-      }
-      
-      # add this table to the summary sheet
+    # add this table to the summary sheet
+    add_summary_table_to_sheet(wb,
+                               sheet = summary_sheet_name,
+                               group_tally_table_unsampled,
+                               table_start_row,
+                               table_start_col = 1,
+                               Total_row = FALSE)
+    
+    #if the sampled and unsampled data have different lengths, then repeat for sampled data
+    if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+      group_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
+                                                           cols_to_use = "group_columns")
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
-                                 group_tally_table_unsampled,
+                                 group_tally_table_sampled, 
                                  table_start_row,
-                                 table_start_col = 1,
+                                 #this is printed to the right of the unsampled dataframe
+                                 table_start_col = ncol(group_tally_table_unsampled)+3,
                                  Total_row = FALSE)
-      
-      #if the sampled and unsampled data have different lengths, then do the same for the sampled data
-      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        group_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
-                                                             cols_to_use = "group_columns")
-        add_summary_table_to_sheet(wb,
-                                   sheet = summary_sheet_name,
-                                   group_tally_table_sampled, 
-                                   table_start_row,
-                                   #this is printed to the right of the unsampled dataframe
-                                   table_start_col = ncol(group_tally_table_unsampled)+3,
-                                   Total_row = FALSE)
-      }
-      
-      # increment start row to allow next table/content to be further down on page
-      table_start_row <- table_start_row + nrow(group_tally_table_unsampled) + 3
     }
     
-  # create and add the term tally tables underneath the header
-    for (term_columns in database_name) {
-      # create term tally table for unsampled data and apply make_text_terms_pretty function
-      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
-                                                            cols_to_use = "term_columns")
+    # increment start row to allow next table/content to be further down on page
+    table_start_row <- table_start_row + nrow(group_tally_table_unsampled) + 3
+    
 
-      #add headers for sampled/unsampled tables where sampling took place
-      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        table_start_row <- add_text_to_summary_sheets(wb, 
-                                                      sheet = summary_sheet_name,
-                                                      content_start_row = table_start_row,
-                                                      text_to_add = "sampled_table_headers")
-      }
-      
-      # add this table to the summary sheet
+    # create unsampled term tally table
+    term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
+                                                          cols_to_use = "term_columns")
+    
+    # add this table to the summary sheet
+    add_summary_table_to_sheet(wb,
+                               sheet = summary_sheet_name,
+                               term_tally_table_unsampled,
+                               table_start_row,
+                               table_start_col = 1,
+                               Total_row = FALSE)
+    
+    #if the sampled and unsampled data have different lengths, then repeat sampled data
+    if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+      term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
+                                                          cols_to_use = "term_columns")
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
-                                 term_tally_table_unsampled,
+                                 term_tally_table_sampled, 
                                  table_start_row,
-                                 table_start_col = 1,
+                                 #this is printed to the right of the unsampled dataframe
+                                 table_start_col = ncol(term_tally_table_unsampled)+3,
                                  Total_row = FALSE)
-      
-      #if the sampled and unsampled data have different lengths, then do the same for the sampled data
-      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
-                                                            cols_to_use = "term_columns")
-        add_summary_table_to_sheet(wb,
-                                   sheet = summary_sheet_name,
-                                   term_tally_table_sampled, 
-                                   table_start_row,
-                                   #this is printed to the right of the unsampled dataframe
-                                   table_start_col = ncol(term_tally_table_unsampled)+3,
-                                   Total_row = FALSE)
-      }
-      
-      # increment start row to allow next table/content to be further down on page
-      table_start_row <- table_start_row + nrow(term_tally_table_unsampled) + 3
     }
+    
+    # increment start row to allow next table/content to be further down on page
+    table_start_row <- table_start_row + nrow(term_tally_table_unsampled) + 3
   }
   
     ## CREATE INCIDENT LEVEL DATA IF REQUIRED

--- a/formatter.R
+++ b/formatter.R
@@ -196,12 +196,12 @@ for (i in file_list) {
     }
   
   
-  # increment start row to allow next table to be further down on page
+  # header for the term tally table
   table_start_row <- add_term_tally_table_header(wb, 
                                                  sheet = summary_sheet_name,
                                                  content_start_row = table_start_row)
   
-  # repeat for term tally tables for the same sheets
+  # create and add the term tally tables underneath the header
   for (term_columns in database_name) {
     # create term tally table for unsampled data and add to sheet with styling
     term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
@@ -222,7 +222,7 @@ for (i in file_list) {
                                  table_start_col = ncol(summary_table_unsampled)+2)
     }
     
-    # increment start row to allow next table to be further down on page
+    # increment start row to allow next table/content to be further down on page
     table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
   }
   

--- a/formatter.R
+++ b/formatter.R
@@ -202,7 +202,8 @@ for (i in file_list) {
     # create and add the group tally tables underneath the header
     for (group_columns in database_name) {
       # create term tally table for unsampled data and apply make_text_terms_pretty function
-      group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, cols_to_use = "group_columns")
+      group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
+                                                             cols_to_use = "group_columns")
       # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
@@ -213,13 +214,14 @@ for (i in file_list) {
       
       #if the sampled and unsampled data have different lengths, then do the same for the sampled data
       if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        group_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, cols_to_use = "group_columns")
+        group_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
+                                                             cols_to_use = "group_columns")
         add_summary_table_to_sheet(wb,
                                    sheet = summary_sheet_name,
                                    group_tally_table_sampled, 
                                    table_start_row,
                                    #this is printed to the right of the unsampled dataframe
-                                   table_start_col = ncol(summary_table_unsampled)+2,
+                                   table_start_col = ncol(group_tally_table_unsampled)+3,
                                    Total_row = FALSE)
       }
       
@@ -230,7 +232,8 @@ for (i in file_list) {
   # create and add the term tally tables underneath the header
     for (term_columns in database_name) {
       # create term tally table for unsampled data and apply make_text_terms_pretty function
-      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, cols_to_use = "term_columns")
+      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
+                                                            cols_to_use = "term_columns")
       term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
       # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
@@ -242,14 +245,15 @@ for (i in file_list) {
       
       #if the sampled and unsampled data have different lengths, then do the same for the sampled data
       if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, cols_to_use = "term_columns")
+        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
+                                                            cols_to_use = "term_columns")
         term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
         add_summary_table_to_sheet(wb,
                                    sheet = summary_sheet_name,
                                    term_tally_table_sampled, 
                                    table_start_row,
                                    #this is printed to the right of the unsampled dataframe
-                                   table_start_col = ncol(summary_table_unsampled)+2,
+                                   table_start_col = ncol(term_tally_table_unsampled)+3,
                                    Total_row = FALSE)
       }
       

--- a/formatter.R
+++ b/formatter.R
@@ -195,6 +195,28 @@ for (i in file_list) {
       
     }
   
+  # repeat for term tally tables for the same sheets
+  for (term_columns in database_name) {
+    # create term tally table for unsampled data and add to sheet with styling
+    term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
+    add_summary_table_to_sheet(wb,
+                               sheet = summary_sheet_name,
+                               term_tally_table_unsampled,
+                               table_start_row,
+                               table_start_col = 1)
+    
+    #if the sampled and unsampled data have different lengths, then create and add a summary table for the sampled data
+    if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+      term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level)
+      add_summary_table_to_sheet(wb,
+                                 sheet = summary_sheet_name,
+                                 term_tally_table_sampled, 
+                                 table_start_row,
+                                 #this is printed to the right of the unsampled dataframe
+                                 table_start_col = ncol(summary_table_unsampled)+2)
+    }
+  }
+  
     ## CREATE INCIDENT LEVEL DATA IF REQUIRED
   
     #if incident level data is required, then we add a sheet with this data  

--- a/formatter.R
+++ b/formatter.R
@@ -204,7 +204,8 @@ for (i in file_list) {
                                sheet = summary_sheet_name,
                                term_tally_table_unsampled,
                                table_start_row,
-                               table_start_col = 1)
+                               table_start_col = 1,
+                               Total_row = FALSE)
     
     #if the sampled and unsampled data have different lengths, then do the same for the sampled data
     if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
@@ -215,7 +216,8 @@ for (i in file_list) {
                                  term_tally_table_sampled, 
                                  table_start_row,
                                  #this is printed to the right of the unsampled dataframe
-                                 table_start_col = ncol(summary_table_unsampled)+2)
+                                 table_start_col = ncol(summary_table_unsampled)+2,
+                                 Total_row = FALSE)
     }
     
     # increment start row to allow next table/content to be further down on page

--- a/formatter.R
+++ b/formatter.R
@@ -195,6 +195,20 @@ for (i in file_list) {
       
     }
   
+  # add in a note between this table and the term tally table
+  note <- c(
+    "Explain table",
+    "Note: Caveat"
+    )
+  writeData(wb, 
+            sheet = summary_sheet_name, 
+            x = note, 
+            startRow = table_start_row, 
+            startCol = 1)
+  
+  # increment start row to allow next table to be further down on page
+  table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
+  
   # repeat for term tally tables for the same sheets
   for (term_columns in database_name) {
     # create term tally table for unsampled data and add to sheet with styling
@@ -215,6 +229,9 @@ for (i in file_list) {
                                  #this is printed to the right of the unsampled dataframe
                                  table_start_col = ncol(summary_table_unsampled)+2)
     }
+    
+    # increment start row to allow next table to be further down on page
+    table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
   }
   
     ## CREATE INCIDENT LEVEL DATA IF REQUIRED
@@ -273,5 +290,6 @@ tf <- tempfile(fileext = ".xlsx")
 saveWorkbook(wb, 
              file = tf,
              overwrite = T)
+
 
 source('microsoft365R.R')

--- a/formatter.R
+++ b/formatter.R
@@ -63,12 +63,13 @@ date_type_text <-
 
 date_range <- glue('Incidents {date_type_text} between {format(as.Date(start_date), "%d-%b-%y")} and {format(as.Date(end_date), "%d-%b-%y")}')
 
-
-text_terms_pretty <- text_terms
-for (group in 1:length(text_terms)){
-  for (term in 1:length(text_terms[[group]])){
+if(sum(!is.na(text_terms)) > 0) {
+  text_terms_pretty <- text_terms
+  for (group in 1:length(text_terms)){
+    for (term in 1:length(text_terms[[group]])){
       prettier_term <- make_text_terms_pretty((text_terms[[group]][term]))
       text_terms_pretty[[group]][term] <- prettier_term
+    }
   }
 }
 
@@ -188,40 +189,42 @@ for (i in file_list) {
       
     }
   
-  
-  # header for the term tally table
-  table_start_row <- add_term_tally_table_header(wb, 
-                                                 sheet = summary_sheet_name,
-                                                 content_start_row = table_start_row)
+  # checking that there are text terms in search strategy
+  if(sum(!is.na(text_terms)) > 0 && include_term_tally_table == "yes"){
+    # header for the term tally table
+    table_start_row <- add_term_tally_table_header(wb, 
+                                                  sheet = summary_sheet_name,
+                                                  content_start_row = table_start_row)
   
   # create and add the term tally tables underneath the header
-  for (term_columns in database_name) {
-    # create term tally table for unsampled data and apply make_text_terms_pretty function
-    term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
-    term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
-    # add this table to the summary sheet
-    add_summary_table_to_sheet(wb,
-                               sheet = summary_sheet_name,
-                               term_tally_table_unsampled,
-                               table_start_row,
-                               table_start_col = 1,
-                               Total_row = FALSE)
-    
-    #if the sampled and unsampled data have different lengths, then do the same for the sampled data
-    if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-      term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level)
-      term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
+    for (term_columns in database_name) {
+      # create term tally table for unsampled data and apply make_text_terms_pretty function
+      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
+      term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
+      # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
-                                 term_tally_table_sampled, 
+                                 term_tally_table_unsampled,
                                  table_start_row,
-                                 #this is printed to the right of the unsampled dataframe
-                                 table_start_col = ncol(summary_table_unsampled)+2,
+                                 table_start_col = 1,
                                  Total_row = FALSE)
+      
+      #if the sampled and unsampled data have different lengths, then do the same for the sampled data
+      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level)
+        term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
+        add_summary_table_to_sheet(wb,
+                                   sheet = summary_sheet_name,
+                                   term_tally_table_sampled, 
+                                   table_start_row,
+                                   #this is printed to the right of the unsampled dataframe
+                                   table_start_col = ncol(summary_table_unsampled)+2,
+                                   Total_row = FALSE)
+      }
+      
+      # increment start row to allow next table/content to be further down on page
+      table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
     }
-    
-    # increment start row to allow next table/content to be further down on page
-    table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
   }
   
     ## CREATE INCIDENT LEVEL DATA IF REQUIRED

--- a/formatter.R
+++ b/formatter.R
@@ -158,6 +158,14 @@ for (i in file_list) {
       summary_table_unsampled<- create_summary_table(df_unsampled_incident_level,
                                                      variables_to_tabulate_by_list, 
                                                      database_name)
+      
+      #add headers for sampled/unsampled tables where sampling took place
+      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+        table_start_row <- add_text_to_summary_sheets(wb, 
+                                                      sheet = summary_sheet_name,
+                                                      content_start_row = table_start_row,
+                                                      text_to_add = "sampled_table_headers")
+      }
 
       #add this summary table to the sheet, and adds styling
       add_summary_table_to_sheet(wb,
@@ -195,15 +203,26 @@ for (i in file_list) {
   if(sum(!is.na(text_terms)) > 0 && include_term_tally_table == "yes"){
     
     # header for the group/term tally table
-    table_start_row <- add_term_tally_table_header(wb, 
+    table_start_row <- add_text_to_summary_sheets(wb, 
                                                   sheet = summary_sheet_name,
-                                                  content_start_row = table_start_row)
+                                                  content_start_row = table_start_row,
+                                                  text_to_add = "term_tally_table_heading"
+                                                  )
     
     # create and add the group tally tables underneath the header
     for (group_columns in database_name) {
       # create term tally table for unsampled data and apply make_text_terms_pretty function
       group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
                                                              cols_to_use = "group_columns")
+      
+      #add headers for sampled/unsampled tables where sampling took place
+      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+        table_start_row <- add_text_to_summary_sheets(wb, 
+                                                      sheet = summary_sheet_name,
+                                                      content_start_row = table_start_row,
+                                                      text_to_add = "sampled_table_headers")
+      }
+      
       # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
@@ -235,6 +254,15 @@ for (i in file_list) {
       term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
                                                             cols_to_use = "term_columns")
       term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
+      
+      #add headers for sampled/unsampled tables where sampling took place
+      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+        table_start_row <- add_text_to_summary_sheets(wb, 
+                                                      sheet = summary_sheet_name,
+                                                      content_start_row = table_start_row,
+                                                      text_to_add = "sampled_table_headers")
+      }
+      
       # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,

--- a/formatter.R
+++ b/formatter.R
@@ -67,15 +67,8 @@ date_range <- glue('Incidents {date_type_text} between {format(as.Date(start_dat
 text_terms_pretty <- text_terms
 for (group in 1:length(text_terms)){
   for (term in 1:length(text_terms[[group]])){
-      prettier_term<-text_terms[[group]][term] |>
-      str_replace_all(pattern = "\\|", " OR ") |>
-      str_replace_all(pattern = "\\|", " OR ") |>
-      str_replace_all(pattern = fixed('\\b'), "%") |>
-
-      str_replace_all(pattern = fixed('(?i)'), "" ) |>
-
-      str_replace_all(pattern =  "\\(\\?:\\|\\\\W\\)", "~")
-    text_terms_pretty[[group]][term]<-prettier_term
+      prettier_term <- make_text_terms_pretty((text_terms[[group]][term]))
+      text_terms_pretty[[group]][term] <- prettier_term
   }
 }
 
@@ -203,17 +196,20 @@ for (i in file_list) {
   
   # create and add the term tally tables underneath the header
   for (term_columns in database_name) {
-    # create term tally table for unsampled data and add to sheet with styling
+    # create term tally table for unsampled data and apply make_text_terms_pretty function
     term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
+    term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
+    # add this table to the summary sheet
     add_summary_table_to_sheet(wb,
                                sheet = summary_sheet_name,
                                term_tally_table_unsampled,
                                table_start_row,
                                table_start_col = 1)
     
-    #if the sampled and unsampled data have different lengths, then create and add a summary table for the sampled data
+    #if the sampled and unsampled data have different lengths, then do the same for the sampled data
     if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
       term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level)
+      term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
       add_summary_table_to_sheet(wb,
                                  sheet = summary_sheet_name,
                                  term_tally_table_sampled, 

--- a/formatter.R
+++ b/formatter.R
@@ -253,8 +253,7 @@ for (i in file_list) {
       # create term tally table for unsampled data and apply make_text_terms_pretty function
       term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, 
                                                             cols_to_use = "term_columns")
-      term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
-      
+
       #add headers for sampled/unsampled tables where sampling took place
       if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
         table_start_row <- add_text_to_summary_sheets(wb, 
@@ -275,7 +274,6 @@ for (i in file_list) {
       if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
         term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, 
                                                             cols_to_use = "term_columns")
-        term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
         add_summary_table_to_sheet(wb,
                                    sheet = summary_sheet_name,
                                    term_tally_table_sampled, 

--- a/formatter.R
+++ b/formatter.R
@@ -191,15 +191,44 @@ for (i in file_list) {
   
   # checking that there are text terms in search strategy
   if(sum(!is.na(text_terms)) > 0 && include_term_tally_table == "yes"){
-    # header for the term tally table
+    
+    # header for the group/term tally table
     table_start_row <- add_term_tally_table_header(wb, 
                                                   sheet = summary_sheet_name,
                                                   content_start_row = table_start_row)
-  
+    
+    # create and add the group tally tables underneath the header
+    for (group_columns in database_name) {
+      # create term tally table for unsampled data and apply make_text_terms_pretty function
+      group_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, cols_to_use = "group_columns")
+      # add this table to the summary sheet
+      add_summary_table_to_sheet(wb,
+                                 sheet = summary_sheet_name,
+                                 group_tally_table_unsampled,
+                                 table_start_row,
+                                 table_start_col = 1,
+                                 Total_row = FALSE)
+      
+      #if the sampled and unsampled data have different lengths, then do the same for the sampled data
+      if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
+        group_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, cols_to_use = "group_columns")
+        add_summary_table_to_sheet(wb,
+                                   sheet = summary_sheet_name,
+                                   group_tally_table_sampled, 
+                                   table_start_row,
+                                   #this is printed to the right of the unsampled dataframe
+                                   table_start_col = ncol(summary_table_unsampled)+2,
+                                   Total_row = FALSE)
+      }
+      
+      # increment start row to allow next table/content to be further down on page
+      table_start_row <- table_start_row + nrow(group_tally_table_unsampled) + 3
+    }
+    
   # create and add the term tally tables underneath the header
     for (term_columns in database_name) {
       # create term tally table for unsampled data and apply make_text_terms_pretty function
-      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level)
+      term_tally_table_unsampled <- create_term_tally_table(df_unsampled_incident_level, cols_to_use = "term_columns")
       term_tally_table_unsampled <- sapply(term_tally_table_unsampled, make_text_terms_pretty)
       # add this table to the summary sheet
       add_summary_table_to_sheet(wb,
@@ -211,7 +240,7 @@ for (i in file_list) {
       
       #if the sampled and unsampled data have different lengths, then do the same for the sampled data
       if (nrow(df_unsampled_incident_level)!=nrow(df_sampled_incident_level)){
-        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level)
+        term_tally_table_sampled <- create_term_tally_table(df_sampled_incident_level, cols_to_use = "term_columns")
         term_tally_table_sampled <- sapply(term_tally_table_sampled, make_text_terms_pretty)
         add_summary_table_to_sheet(wb,
                                    sheet = summary_sheet_name,
@@ -223,7 +252,7 @@ for (i in file_list) {
       }
       
       # increment start row to allow next table/content to be further down on page
-      table_start_row <- table_start_row + nrow(summary_table_unsampled) + 3
+      table_start_row <- table_start_row + nrow(term_tally_table_unsampled) + 3
     }
   }
   

--- a/formatter.R
+++ b/formatter.R
@@ -71,6 +71,8 @@ if(sum(!is.na(text_terms)) > 0) {
       text_terms_pretty[[group]][term] <- prettier_term
     }
   }
+} else  {
+  text_terms_pretty <- "No text filters"
 }
 
 metadata_answers <- c(

--- a/functions.R
+++ b/functions.R
@@ -221,14 +221,8 @@ create_term_tally_table <- function(df_to_create_term_tally,
       select(matches("term")) |>
       summarise(across(everything(), ~sum(. == TRUE, na.rm = TRUE))) |>
       pivot_longer(cols = everything(), names_to = "Search term", values_to = "n")
-    # style the format of the search terms in the table
-    summary_table <- summary_table |>
-      mutate(
-        `Search term` = `Search term` |>
-          str_replace_all("_", " ") |>
-          str_replace("term", "term:") |>
-          str_replace_all("group", "Group")
-      )
+    # style the format of the search term column in the table
+    summary_table$`Search term` <- sapply(summary_table$`Search term`, make_text_terms_pretty)
   }
 
   # calculate the number of incidences identified by each search group
@@ -238,13 +232,8 @@ create_term_tally_table <- function(df_to_create_term_tally,
       select(matches("group_\\D{1}\\b")) |>
       summarise(across(everything(), ~sum(. == TRUE, na.rm = TRUE))) |>
       pivot_longer(cols = everything(), names_to = "Group", values_to = "n")
-    # style the format of the groups in the table
-    summary_table <- summary_table |>
-      mutate(
-        Group = Group |> 
-          str_replace_all("_", " ") |> 
-          str_replace_all("group", "Group")
-      )
+    # style the format of the group column in the table
+    summary_table$Group <- sapply(summary_table$Group, make_text_terms_pretty)
   }
 
   return(summary_table)
@@ -599,5 +588,8 @@ make_text_terms_pretty <- function(term){
     str_replace_all(pattern = fixed("(?:\\W|"), "~") |>
     str_replace_all(pattern = "\\|", " OR ") |>
     str_replace_all(pattern = fixed('\\b'), "%" ) |>
-    str_replace_all(pattern = fixed('(?i)'), "" )
+    str_replace_all(pattern = fixed('(?i)'), "" ) |>
+    str_replace_all("_", " ") |>
+    str_replace("term", "term:") |>
+    str_replace_all("group", "Group")
 }

--- a/functions.R
+++ b/functions.R
@@ -79,7 +79,7 @@ add_header_to_sheet <- function(wb, title,
 add_term_tally_table_header <- function(wb, 
                                         sheet,
                                         content_start_row) {
-  # Explain what the term tally table is
+  # Explain what the group/term tally tables show
   writeData(
     wb,
     sheet,
@@ -88,7 +88,7 @@ add_term_tally_table_header <- function(wb,
     startRow = content_start_row
   )
   
-  # Add in caveat for term tally table about why the number of incidents don't equal the total
+  # Add in caveat about not being able to sum the numbers of terms/groups
   writeData(
     wb,
     sheet,

--- a/functions.R
+++ b/functions.R
@@ -75,6 +75,38 @@ add_header_to_sheet <- function(wb, title,
 }
 
 
+# this function adds a note prior to the term tally table in the summary sheets
+add_term_tally_table_header <- function(wb, 
+                                        sheet,
+                                        content_start_row) {
+  # Explain what the term tally table is
+  writeData(
+    wb,
+    sheet,
+    paste(str_glue("The following number of incidents were retrieved by each term in the search strategy.")),
+    startCol = 1,
+    startRow = content_start_row
+  )
+  
+  # Add in caveat for term tally table about why the number of incidents don't equal the total
+  writeData(
+    wb,
+    sheet,
+    paste(str_glue("Note: The total number of incidents retrieved may not match the sum of incidents for each term as multiple search terms can be used to identify a single incident.")),
+    startCol = 1,
+    startRow = content_start_row + 1
+  )
+  
+  # set start row for term tally tables
+  table_start_row <- content_start_row + 3
+  
+  # Add text style
+  addStyle(wb, sheet = sheet, textStyle, rows = 1:(table_start_row - 1), cols = 1)
+  
+  return(table_start_row)
+}
+
+
 # this function creates a summary table from a dataframe and a list containing the variables to tabulate by
 create_summary_table <- function(df_to_create_summary_table,
                                  variables_to_tabulate_by_list,

--- a/functions.R
+++ b/functions.R
@@ -331,8 +331,14 @@ add_summary_table_to_sheet <- function(wb,
 
   setColWidths(wb,
     sheet = sheet,
-    cols = table_start_col:(table_start_col + ncol(summary_table) - 1),
-    widths = 20
+    cols = table_start_col,
+    widths = 30
+  )
+  
+  setColWidths(wb,
+    sheet = sheet,
+    cols = (table_start_col + 1):(table_start_col + ncol(summary_table) - 1),
+    widths = 15
   )
 
   # style table - header

--- a/functions.R
+++ b/functions.R
@@ -101,7 +101,7 @@ add_term_tally_table_header <- function(wb,
   table_start_row <- content_start_row + 3
   
   # Add text style
-  addStyle(wb, sheet = sheet, textStyle, rows = 1:(table_start_row - 1), cols = 1)
+  addStyle(wb, sheet = sheet, textStyle, rows = content_start_row:(table_start_row - 1), cols = 1)
   
   return(table_start_row)
 }

--- a/functions.R
+++ b/functions.R
@@ -151,6 +151,27 @@ create_summary_table <- function(df_to_create_summary_table,
   return(summary_table)
 }
 
+# function to create term tally table
+create_term_tally_table <- function(df_to_create_term_tally) {
+  
+  # select all term columns
+  term_columns <- grep("term", names(df_to_create_term_tally), value = TRUE)
+  
+  # verify that text terms have been provided
+  if(length(term_columns) < 1){
+    message(str_glue("No search terms provided. Table cannot be created."))
+    return(tibble(`Table could not be made` = str_glue("No search terms provided.")))
+  }
+  
+  # calculate the number of incidences identified by each search term (by summing number of TRUE values)
+  summary_table <- df_to_create_term_tally |>
+    summarise(across(all_of(term_columns), ~sum(. == TRUE, na.rm = TRUE))) |>
+    pivot_longer(cols = everything(), names_to = "Search term", values_to = "n")
+  
+  return(summary_table)
+}
+
+
 # function to convert month and level of harm columns to factors (depending on database)
 convert_columns_to_factors <- function(df_without_factors, database_name) {
   # convert month and harm level to ordered factors

--- a/functions.R
+++ b/functions.R
@@ -84,7 +84,7 @@ add_text_to_summary_sheets <- function(wb, sheet,
     # Explain what the group/term tally tables show
     writeData(
       wb, sheet,
-      paste(str_glue("The tables below present the number of incidents identified by each group and text term in the search strategy.")),
+      paste("The tables below present the number of incidents identified by each group and text term in the search strategy."),
       startCol = 1,
       startRow = content_start_row
     )
@@ -92,7 +92,7 @@ add_text_to_summary_sheets <- function(wb, sheet,
     # Add in caveat about not being able to sum the numbers of terms/groups
     writeData(
       wb, sheet,
-      paste(str_glue("Note: A single incident can be identified by multiple groups and text terms, so the number of incidents identified by different terms/groups are not summable.")),
+      paste("Note: A single incident can be identified by multiple groups and text terms, so the number of incidents identified by different terms/groups are not summable."),
       startCol = 1,
       startRow = content_start_row + 1
     )
@@ -108,7 +108,7 @@ add_text_to_summary_sheets <- function(wb, sheet,
     # Add header for unsampled tables
     writeData(
       wb, sheet,
-      paste(str_glue("Search strategy:")),
+      paste("Search strategy:"),
       startCol = 1,
       startRow = content_start_row
     )
@@ -116,7 +116,7 @@ add_text_to_summary_sheets <- function(wb, sheet,
     # Add header for sampled tables
     writeData(
       wb, sheet,
-      paste(str_glue("Sample:")),
+      paste("Sample:"),
       startCol = ncol(summary_table_unsampled) + 2,
       startRow = content_start_row
     )

--- a/functions.R
+++ b/functions.R
@@ -48,11 +48,16 @@ add_header_to_sheet <- function(wb, title,
     !summary_sheet & database_name == "LFPSE" ~ " (patient level)",
     .default = ""
   )
+  
+  # format number of sampled/unsampled incidents to have comma separation
+  number_of_rows_unsampled_formatted <- format(number_of_rows_unsampled, big.mark = ",", scientific=F)
+  number_of_rows_sampled_formatted <- format(number_of_rows_sampled, big.mark = ",", scientific=F)
+  
   # write number of incidents
   writeData(
     wb,
     sheet,
-    paste(str_glue("Number of Incidents retrieved by search strategy{incident_or_pt_level}: {number_of_rows_unsampled}")),
+    paste(str_glue("Number of Incidents retrieved by search strategy{incident_or_pt_level}: {number_of_rows_unsampled_formatted}")),
     startCol = 1,
     startRow = content_start_row
   )
@@ -60,7 +65,7 @@ add_header_to_sheet <- function(wb, title,
   writeData(
     wb,
     sheet,
-    paste(str_glue("Number of Incidents in Sample{incident_or_pt_level}: {number_of_rows_sampled}")),
+    paste(str_glue("Number of Incidents in Sample{incident_or_pt_level}: {number_of_rows_sampled_formatted}")),
     startCol = 1,
     startRow = content_start_row + 1
   )

--- a/functions.R
+++ b/functions.R
@@ -189,37 +189,34 @@ create_term_tally_table <- function(df_to_create_term_tally,
   
   # calculate the number of incidences identified by each search term
   if(cols_to_use=="term_columns") {
-    # identify the term columns
-    term_columns <- grep("term", names(df_to_create_term_tally), value = TRUE)
-    # sum the number of True values in each column
+    # sum the number of True values in each term column
     summary_table <- df_to_create_term_tally |>
-      summarise(across(all_of(term_columns), ~sum(. == TRUE, na.rm = TRUE))) |>
+      select(matches("term")) |>
+      summarise(across(everything(), ~sum(. == TRUE, na.rm = TRUE))) |>
       pivot_longer(cols = everything(), names_to = "Search term", values_to = "n")
     # style the format of the search terms in the table
     summary_table <- summary_table |>
       mutate(
-        `Search term` = str_replace_all(`Search term`, "_", " "),
-        `Search term` = str_replace(`Search term`, "term", "term:"),
-        `Search term` = str_to_upper(str_sub(`Search term`, 1, 1)) |>
-        paste0(str_sub(`Search term`, 2, nchar(`Search term`)))
+        `Search term` = `Search term` |>
+          str_replace_all("_", " ") |>
+          str_replace("term", "term:") |>
+          str_replace_all("group", "Group")
       )
   }
 
   # calculate the number of incidences identified by each search group
   if(cols_to_use=="group_columns") {
-    # identify the group columns
-    group_columns <- grep("group", names(df_to_create_term_tally), value = TRUE)
-    group_columns <- group_columns[!grepl("term", group_columns)]
-    # sum the number of True values in each column
+    # sum the number of True values in each group column
     summary_table <- df_to_create_term_tally |>
-      summarise(across(all_of(group_columns), ~sum(. == TRUE, na.rm = TRUE))) |>
+      select(matches("group_\\D{1}\\b")) |>
+      summarise(across(everything(), ~sum(. == TRUE, na.rm = TRUE))) |>
       pivot_longer(cols = everything(), names_to = "Group", values_to = "n")
     # style the format of the groups in the table
     summary_table <- summary_table |>
       mutate(
         Group = Group |> 
           str_replace_all("_", " ") |> 
-          str_to_title()
+          str_replace_all("group", "Group")
       )
   }
 

--- a/functions.R
+++ b/functions.R
@@ -80,8 +80,6 @@ add_text_to_summary_sheets <- function(wb, sheet,
                                        content_start_row,
                                        text_to_add) {
   
-  table_start_row
-  
   if(text_to_add=="term_tally_table_heading"){
     # Explain what the group/term tally tables show
     writeData(
@@ -589,7 +587,7 @@ make_text_terms_pretty <- function(term){
     str_replace_all(pattern = "\\|", " OR ") |>
     str_replace_all(pattern = fixed('\\b'), "%" ) |>
     str_replace_all(pattern = fixed('(?i)'), "" ) |>
-    str_replace_all("_", " ") |>
-    str_replace("term", "term:") |>
-    str_replace_all("group", "Group")
+    str_replace("term_", "term: ") |>
+    str_replace_all("group_", "Group ") |>
+    str_replace_all("_", " ")
 }

--- a/functions.R
+++ b/functions.R
@@ -200,10 +200,6 @@ create_term_tally_table <- function(df_to_create_term_tally) {
     summarise(across(all_of(term_columns), ~sum(. == TRUE, na.rm = TRUE))) |>
     pivot_longer(cols = everything(), names_to = "Search term", values_to = "n")
   
-  # add a total row which calculates the total number of incidents in the data frame
-  total_row <- tibble(`Search term` = "Total", `n` = nrow(df_to_create_term_tally))
-  summary_table <- bind_rows(summary_table, total_row)
-  
   # add styling to improve look of the Search term column in the output tables
   summary_table <- summary_table |>
     mutate(
@@ -290,7 +286,8 @@ add_summary_table_to_sheet <- function(wb,
                                        sheet,
                                        summary_table,
                                        table_start_row,
-                                       table_start_col) {
+                                       table_start_col,
+                                       Total_row = TRUE) {
   # add summary table to sheet
   writeData(wb, sheet, summary_table, startRow = table_start_row, startCol = table_start_col, keepNA = TRUE, na.string = "Not available")
 
@@ -314,7 +311,7 @@ add_summary_table_to_sheet <- function(wb,
     wb,
     sheet = sheet,
     rowTitleStyle,
-    rows = (table_start_row + 1):(nrow(summary_table) + table_start_row - 1),
+    rows = (table_start_row + 1):(nrow(summary_table) + table_start_row),
     cols = table_start_col
   )
 
@@ -323,21 +320,24 @@ add_summary_table_to_sheet <- function(wb,
     wb,
     sheet = sheet,
     bodyStyleNoBorder,
-    rows = (table_start_row + 1):(nrow(summary_table) + table_start_row - 1),
+    rows = (table_start_row + 1):(nrow(summary_table) + table_start_row),
     cols = (table_start_col + 1):(table_start_col + ncol(summary_table) - 1),
     gridExpand = T
   )
 
-  # style table- header and footer
-  addStyle(
-    wb,
-    sheet = sheet,
-    summaryTableTopBottomStyle,
-    rows = nrow(summary_table) + table_start_row,
-    cols = table_start_col:(table_start_col + ncol(summary_table) - 1),
-    gridExpand = T
-  )
+  # style table- footer with border when there is a total row
+  if(Total_row == T){
+    addStyle(
+        wb,
+        sheet = sheet,
+        summaryTableTopBottomStyle,
+        rows = nrow(summary_table) + table_start_row,
+        cols = table_start_col:(table_start_col + ncol(summary_table) - 1),
+        gridExpand = T
+      ) 
+  }
 }
+
 
 # this function adds a data table to a sheet and styles it
 add_data_table_to_sheet <- function(wb,

--- a/functions.R
+++ b/functions.R
@@ -209,7 +209,8 @@ create_term_tally_table <- function(df_to_create_term_tally) {
     mutate(
       `Search term` = str_replace_all(`Search term`, "_", " "),
       `Search term` = str_replace(`Search term`, "term", "term:"),
-      #`Search term` = str_to_title(`Search term`)
+      `Search term` = str_to_upper(str_sub(`Search term`, 1, 1)) |>
+        paste0(str_sub(`Search term`, 2, nchar(`Search term`)))
     )
   
   return(summary_table)

--- a/functions.R
+++ b/functions.R
@@ -204,6 +204,14 @@ create_term_tally_table <- function(df_to_create_term_tally) {
   total_row <- tibble(`Search term` = "Total", `n` = nrow(df_to_create_term_tally))
   summary_table <- bind_rows(summary_table, total_row)
   
+  # add styling to improve look of the Search term column in the output tables
+  summary_table <- summary_table |>
+    mutate(
+      `Search term` = str_replace_all(`Search term`, "_", " "),
+      `Search term` = str_replace(`Search term`, "term", "term:"),
+      #`Search term` = str_to_title(`Search term`)
+    )
+  
   return(summary_table)
 }
 
@@ -537,4 +545,14 @@ translate_categorical_string <- function(categorical_filter, database_name) {
   }
 
   return(translated_filters)
+}
+
+
+
+make_text_terms_pretty <- function(term){
+  term |>
+    str_replace_all(pattern = fixed("(?:\\W|"), "~") |>
+    str_replace_all(pattern = "\\|", " OR ") |>
+    str_replace_all(pattern = fixed('\\b'), "%" ) |>
+    str_replace_all(pattern = fixed('(?i)'), "" )
 }

--- a/functions.R
+++ b/functions.R
@@ -168,6 +168,10 @@ create_term_tally_table <- function(df_to_create_term_tally) {
     summarise(across(all_of(term_columns), ~sum(. == TRUE, na.rm = TRUE))) |>
     pivot_longer(cols = everything(), names_to = "Search term", values_to = "n")
   
+  # add a total row which calculates the total number of incidents in the data frame
+  total_row <- tibble(`Search term` = "Total", `n` = nrow(df_to_create_term_tally))
+  summary_table <- bind_rows(summary_table, total_row)
+  
   return(summary_table)
 }
 

--- a/functions.R
+++ b/functions.R
@@ -76,32 +76,59 @@ add_header_to_sheet <- function(wb, title,
 
 
 # this function adds a note prior to the term tally table in the summary sheets
-add_term_tally_table_header <- function(wb, 
-                                        sheet,
-                                        content_start_row) {
-  # Explain what the group/term tally tables show
-  writeData(
-    wb,
-    sheet,
-    paste(str_glue("The tables below present the number of incidents identified by each group and text term in the search strategy.")),
-    startCol = 1,
-    startRow = content_start_row
-  )
+add_text_to_summary_sheets <- function(wb, sheet,
+                                       content_start_row,
+                                       text_to_add) {
   
-  # Add in caveat about not being able to sum the numbers of terms/groups
-  writeData(
-    wb,
-    sheet,
-    paste(str_glue("Note: A single incident can be identified by multiple groups and text terms, so the number of incidents identified by different terms/groups are not summable.")),
-    startCol = 1,
-    startRow = content_start_row + 1
-  )
+  table_start_row
   
-  # set start row for term tally tables
-  table_start_row <- content_start_row + 3
+  if(text_to_add=="term_tally_table_heading"){
+    # Explain what the group/term tally tables show
+    writeData(
+      wb, sheet,
+      paste(str_glue("The tables below present the number of incidents identified by each group and text term in the search strategy.")),
+      startCol = 1,
+      startRow = content_start_row
+    )
+    
+    # Add in caveat about not being able to sum the numbers of terms/groups
+    writeData(
+      wb, sheet,
+      paste(str_glue("Note: A single incident can be identified by multiple groups and text terms, so the number of incidents identified by different terms/groups are not summable.")),
+      startCol = 1,
+      startRow = content_start_row + 1
+    )
+    
+    # set start row for next content
+    table_start_row <- content_start_row + 3
+    
+    # Add text style
+    addStyle(wb, sheet = sheet, textStyle, rows = content_start_row:(content_start_row + 1), cols = 1)
+  }
   
-  # Add text style
-  addStyle(wb, sheet = sheet, textStyle, rows = content_start_row:(table_start_row - 1), cols = 1)
+  if(text_to_add=="sampled_table_headers"){
+    # Add header for unsampled tables
+    writeData(
+      wb, sheet,
+      paste(str_glue("Search strategy:")),
+      startCol = 1,
+      startRow = content_start_row
+    )
+    
+    # Add header for sampled tables
+    writeData(
+      wb, sheet,
+      paste(str_glue("Sample:")),
+      startCol = ncol(summary_table_unsampled) + 2,
+      startRow = content_start_row
+    )
+    
+    # set the start row for tables
+    table_start_row <- content_start_row + 2
+    
+    # Add text style
+    addStyle(wb, sheet = sheet, textStyle, rows = content_start_row, cols = 1:(ncol(summary_table_unsampled) + 2))
+  }
   
   return(table_start_row)
 }

--- a/functions.R
+++ b/functions.R
@@ -83,7 +83,7 @@ add_term_tally_table_header <- function(wb,
   writeData(
     wb,
     sheet,
-    paste(str_glue("The following number of incidents were retrieved by each term in the search strategy.")),
+    paste(str_glue("The tables below present the number of incidents identified by each group and text term in the search strategy.")),
     startCol = 1,
     startRow = content_start_row
   )
@@ -92,7 +92,7 @@ add_term_tally_table_header <- function(wb,
   writeData(
     wb,
     sheet,
-    paste(str_glue("Note: The total number of incidents retrieved may not match the sum of incidents for each term as multiple search terms can be used to identify a single incident.")),
+    paste(str_glue("Note: A single incident can be identified by multiple groups and text terms, so the number of incidents identified by different terms/groups are not summable.")),
     startCol = 1,
     startRow = content_start_row + 1
   )

--- a/lfpse.R
+++ b/lfpse.R
@@ -157,7 +157,6 @@ if (sum(!is.na(text_terms))>0) {
   
   lfpse_filtered_text <- lfpse_filtered_text_precursor %>%
     filter(!!text_filter) %>%
-    #select(!c(contains("_term_"), concat_col))
     select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(lfpse_filtered_text), big.mark = ',')} incidents."))
@@ -271,13 +270,13 @@ if (nrow(lfpse_filtered_text) != 0) {
     lfpse_for_release_sampled_pt_level <-  lfpse_sampled  |> 
       #rename columns using lookup
       select(any_of(rename_lookup[["LFPSE"]]), starts_with("group_")) |>
-      select(-`Month`, -`Year`, -`Month - Year`)
+      select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
     
     #create patient level table from sampled dataframe and rename columns - this is for data tab
     lfpse_for_release_unsampled_pt_level <-  lfpse_labelled  |> 
       #rename columns using lookup
       select(any_of(rename_lookup[["LFPSE"]]), starts_with("group_"))|>
-      select(-`Month`, -`Year`, -`Month - Year`)
+      select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
     
     message(glue("- Final {dataset} dataset contains {nrow(lfpse_for_release_unsampled_incident_level)} unsampled incidents"))
     message(glue("- Final {dataset} dataset contains {nrow(lfpse_for_release_sampled_incident_level)} sampled incidents."))

--- a/lfpse.R
+++ b/lfpse.R
@@ -157,7 +157,8 @@ if (sum(!is.na(text_terms))>0) {
   
   lfpse_filtered_text <- lfpse_filtered_text_precursor %>%
     filter(!!text_filter) %>%
-    select(!c(contains("_term_"), concat_col))
+    #select(!c(contains("_term_"), concat_col))
+    select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(lfpse_filtered_text), big.mark = ',')} incidents."))
 } else {

--- a/nrls.R
+++ b/nrls.R
@@ -77,7 +77,8 @@ if (sum(!is.na(text_terms)) > 0) {
     # apply text filter logic
     filter(!!text_filter) |>
     # drop individual term columns
-    select(!c(contains("_term_"), concat_col))
+    #select(!c(contains("_term_"), concat_col))
+    select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(nrls_filtered_text), big.mark = ',')} incidents."))
 } else {

--- a/nrls.R
+++ b/nrls.R
@@ -76,8 +76,6 @@ if (sum(!is.na(text_terms)) > 0) {
   nrls_filtered_text <- nrls_filtered_text_precursor |>
     # apply text filter logic
     filter(!!text_filter) |>
-    # drop individual term columns
-    #select(!c(contains("_term_"), concat_col))
     select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(nrls_filtered_text), big.mark = ',')} incidents."))
@@ -167,13 +165,13 @@ if (nrow(nrls_filtered_text) != 0) {
   #create patient level table from sampled dataframe and rename columns - this is for data tab
   nrls_for_release_sampled_pt_level<- nrls_sampled |>
     select(any_of(rename_lookup[["NRLS"]]), starts_with("group_")) |>
-    select(-`Month`, -`Year`, -`Month - Year`)
+    select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
   
   #note: below is very similar to incident level dataframe as nrls is already one row per incident
   #create patient level table from unsampled dataframe and rename columns - this is for data tab
   nrls_for_release_unsampled_pt_level<- nrls_labelled |>
     select(any_of(rename_lookup[["NRLS"]]), starts_with("group_"))|>
-    select(-`Month`, -`Year`, -`Month - Year`)
+    select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
 
   message(glue("- Final {dataset} dataset contains {nrow(nrls_for_release_unsampled_incident_level)} unsampled incidents"))
   message(glue("- Final {dataset} dataset contains {nrow(nrls_for_release_sampled_incident_level)} sampled incidents."))

--- a/params.R
+++ b/params.R
@@ -59,6 +59,9 @@ text_filter <- expr((group_A | group_B) & group_C)
 #text_terms<- list()
 #text_filter<- expr(0)
 
+# do you want to include term/group tally tables in the summary sheets? "yes" or "no"
+include_term_tally_table <- "yes"
+
 # is incident level data required? "yes" or "no"
 incident_level_required<- "yes"
 

--- a/steis.R
+++ b/steis.R
@@ -80,8 +80,6 @@ if (sum(!is.na(text_terms))>0) {
   steis_filtered_text <- steis_filtered_text_precursor %>%
     # apply text filter logic
     filter(!!text_filter) %>%
-    # drop individual term columns
-    #select(!c(contains("_term_"), concat_col)) %>%
     select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(steis_filtered_text), big.mark = ',')} incidents."))
@@ -110,12 +108,12 @@ if(nrow(steis_filtered_text) != 0){
     #note: below is very similar to incident level dataframe as steis is already one row per incident
     #create incident level table from dataframe and rename columns - this is for summary tab
     steis_for_release_unsampled_pt_level<- steis_for_release|>
-      select(-`Month`, -`Year`, -`Month - Year`)
+      select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
     
     #note: below is very similar to incident level dataframe as steis is already one row per incident
     #create incident level table from dataframe and rename columns - this is for summary tab
     steis_for_release_sampled_pt_level <- steis_for_release|>
-      select(-`Month`, -`Year`, -`Month - Year`)
+      select(!c(contains("_term_"), `Month`, `Year`, `Month - Year`))
     
    
   }

--- a/steis.R
+++ b/steis.R
@@ -81,7 +81,8 @@ if (sum(!is.na(text_terms))>0) {
     # apply text filter logic
     filter(!!text_filter) %>%
     # drop individual term columns
-    select(!c(contains("_term_"), concat_col))
+    #select(!c(contains("_term_"), concat_col)) %>%
+    select(-concat_col)
   
   message(glue("{dataset} text search retrieved {format(nrow(steis_filtered_text), big.mark = ',')} incidents."))
 } else {

--- a/styles.R
+++ b/styles.R
@@ -42,7 +42,8 @@ summaryTableTopBottomStyle<- createStyle(
   wrapText = TRUE,
   textDecoration = "bold",
   valign = "center",
-  halign = "left"
+  halign = "left",
+  numFmt = "#,##0"
 )
 
 
@@ -52,9 +53,9 @@ bodyStyleNoBorder <- createStyle(
   fontName = "Arial",
   wrapText = TRUE,
   valign = "center",
-  halign = "left"
+  halign = "left",
+  numFmt = "#,##0"
 )
-
 
 rowTitleStyle <- createStyle(
   fontSize = 11,


### PR DESCRIPTION
Adds two additional tables to the summary sheets in the output file. The first gives the number of incidents identified by each group in the search strategy and the second the number of incidents identified by each term. These tables are only produced where in the params file there are (1) search terms given and (2) include_term_tally_table = "yes".

Creates function 'make_text_terms_pretty' to more easily format the text terms in the output. 

The add_summary_table_to_sheet function is amended to add a toggle for whether or not there is a total row for styling.

