### PR TITLE
51 issues with summary table code

### DIFF
--- a/expand_categorical_filters.R
+++ b/expand_categorical_filters.R
@@ -1,0 +1,7 @@
+
+expanded_categorical_filter_lfpse<-translate_categorical_string(lfpse_categorical, "lfpse")
+expanded_categorical_filter_nrls<-translate_categorical_string(nrls_categorical, "nrls")
+expanded_categorical_filter_steis<-translate_categorical_string(steis_categorical, "steis")
+message(str_glue("LFPSE filter is: \n{expanded_categorical_filter_lfpse}"))
+message(str_glue("NRLS filter is: \n{expanded_categorical_filter_nrls}"))
+message(str_glue("StEIS filter is: \n{expanded_categorical_filter_steis}"))

--- a/expand_categorical_filters.R
+++ b/expand_categorical_filters.R
@@ -1,7 +1,4 @@
-
 expanded_categorical_filter_lfpse<-translate_categorical_string(lfpse_categorical, "lfpse")
 expanded_categorical_filter_nrls<-translate_categorical_string(nrls_categorical, "nrls")
 expanded_categorical_filter_steis<-translate_categorical_string(steis_categorical, "steis")
-message(str_glue("LFPSE filter is: \n{expanded_categorical_filter_lfpse}"))
-message(str_glue("NRLS filter is: \n{expanded_categorical_filter_nrls}"))
-message(str_glue("StEIS filter is: \n{expanded_categorical_filter_steis}"))
+

--- a/functions.R
+++ b/functions.R
@@ -169,7 +169,7 @@ create_summary_table <- function(df_to_create_summary_table,
 
     summary_table <- df_to_create_summary_table |>
       # separate multi select values
-      separate_rows(!!renamed_variable_to_tabulate_by_one_col_name, sep = " {~@~} ") |>
+      separate_rows(!!renamed_variable_to_tabulate_by_one_col_name, sep = "; ") |>
       convert_columns_to_factors(database_name) |>
       # use count to tabulate
       tabyl(!!renamed_variable_to_tabulate_by_one_col_name,
@@ -202,8 +202,8 @@ create_summary_table <- function(df_to_create_summary_table,
 
     summary_table <- df_to_create_summary_table |>
       # separate multi select values
-      separate_rows(!!renamed_variable_to_tabulate_by_one_col_name, sep = " {~@~} ") |>
-      separate_rows(!!renamed_variable_to_tabulate_by_two_col_name, sep = " {~@~} ") |>
+      separate_rows(!!renamed_variable_to_tabulate_by_one_col_name, sep = "; ") |>
+      separate_rows(!!renamed_variable_to_tabulate_by_two_col_name, sep = "; ") |>
       convert_columns_to_factors(database_name) |>
       # use count to get a table
       tabyl(!!renamed_variable_to_tabulate_by_one_col_name,

--- a/functions.R
+++ b/functions.R
@@ -543,13 +543,21 @@ translate_individual_filter <- function(individual_filter, database_name) {
 }
 
 
-# function to translate a categorical filter (as an expression object) into a mure human readable string given a database name
+# function to translate a categorical filter (as an expression object) into a more human readable string given a database name
 translate_categorical_string <- function(categorical_filter, database_name) {
+  if (!get(str_glue("search_{database_name}"))){
+    message(str_glue("{database_name} is not being searched for this query."))
+    if (categorical_filter!= 0){
+      warning(str_glue("{database_name} is not being searched for this query but a filter has been provided. This will not be used."))
+    }
+    return("Database not searched")
+  }
+  
   if (categorical_filter == 0) {
-    message(str_glue("No {database_name} filter"))
+    message(str_glue("No {database_name} filter was provided."))
     return("No categorical filter")
   }
-
+  
   # turn the categorical filter into a string
   categorical_filter_string <- deparse(categorical_filter, width.cutoff = 500)
 
@@ -590,7 +598,7 @@ translate_categorical_string <- function(categorical_filter, database_name) {
     # add the translated filter and AND or OR to the translated_filters string
     translated_filters <- str_c(translated_filters, individual_filter_translated, break_between_filters)
   }
-
+  message(str_glue("{database_name} filter is: \n {translated_filters}"))
   return(translated_filters)
 }
 

--- a/functions.R
+++ b/functions.R
@@ -537,6 +537,9 @@ translate_individual_filter <- function(individual_filter, database_name) {
       # if brackets not around column name- replace column name
       str_replace(str_glue("{column}"), column_new) |>
       str_replace(value, value_new)
+  }else{
+    message(str_glue("{individual_filter} could not be translated"))
+    translated_filter<- individual_filter
   }
 
   return(translated_filter)

--- a/lfpse.R
+++ b/lfpse.R
@@ -88,6 +88,7 @@ lfpse_filtered_categorical <- lfpse_parsed |>
   ### Generate additional columns (without grouping)
   mutate(year_reported_or_occurred = as.numeric(substr(as.character(!!date_filter), 1, 4)),
          month_reported_or_occurred = as.numeric(substr(as.character(!!date_filter), 6, 7)),
+         #zoo package is used to create a year-month object because this will sort in the correct order when tabulated
          month_year_reported_or_occurred = zoo::as.yearmon(str_glue("{year_reported_or_occurred}-{month_reported_or_occurred}")),
          # create financial year while month_reported_or_occurred is still a number
          financial_year_reported_or_occurred = ifelse(month_reported_or_occurred>3,

--- a/nrls.R
+++ b/nrls.R
@@ -39,6 +39,7 @@ nrls_filtered_categorical <- nrls_parsed |>
   collect() |>
   mutate(year_reported_or_occurred = year(!!date_filter),
          month_reported_or_occurred = as.character(month(!!date_filter, label = TRUE, abbr = TRUE)),
+         #zoo package is used to create a year-month object because this will sort in the correct order when tabulated
          month_year_reported_or_occurred = zoo::as.yearmon(!!date_filter),
          financial_year_reported_or_occurred = ifelse(month(!!date_filter)>3, 
                                                       (paste0(year(!!date_filter), '/', year(!!date_filter)+1)),

--- a/params.R
+++ b/params.R
@@ -45,13 +45,6 @@ lfpse_categorical <- expr((' ' + A001 + ' ') %LIKE% '% 4 %')
 steis_categorical <- expr(type_of_incident == 'Medication incident meeting SI criteria')
 steis_filename <- 'SUI_2_87360.csv'
 
-expanded_categorical_filter_lfpse<-translate_categorical_string(lfpse_categorical, "lfpse")
-expanded_categorical_filter_nrls<-translate_categorical_string(nrls_categorical, "nrls")
-expanded_categorical_filter_steis<-translate_categorical_string(steis_categorical, "steis")
-message(str_glue("LFPSE filter is: \n{expanded_categorical_filter_lfpse}"))
-message(str_glue("NRLS filter is: \n{expanded_categorical_filter_nrls}"))
-message(str_glue("StEIS filter is: \n{expanded_categorical_filter_steis}"))
-
 # text terms
 #example below- not real example
 text_terms <- list(
@@ -106,6 +99,7 @@ list_of_tables_to_create_nrls <- list(c(expr(PD09)))
 sampling_strategy <- "default"
 
 
+source("expand_categorical_filters.R")
 #start flow
 source("flow.R")
 

--- a/params.R
+++ b/params.R
@@ -5,6 +5,7 @@ library(here)
 library(openxlsx)
 library(glue)
 library(Microsoft365R)
+library(zoo)
 
 # datasets to be searched (T/F)
 search_nrls <- T

--- a/steis.R
+++ b/steis.R
@@ -31,6 +31,7 @@ steis_parsed <- steis_deduped |>
     reported_date = as.character(floor_date(reported_date, "days")),
     year_reported_or_occurred = year(!!date_filter),
     month_reported_or_occurred = as.character(month(!!date_filter, label = TRUE, abbr = TRUE)),
+    #zoo package is used to create a year-month object because this will sort in the correct order when tabulated
     month_year_reported_or_occurred = zoo::as.yearmon(!!date_filter),
     financial_year_reported_or_occurred = ifelse(month(!!date_filter)>3, 
                                                  (paste0(year(!!date_filter), '/', year(!!date_filter)+1)),


### PR DESCRIPTION
1. fixed bug with splitting by category for summary tables- this works as expected now
2. moved creation of expanded variables into their own script
3. Added a step in translate_categorical_filters to use the search_lfpse, search_nrls, or search_steis objects to check if the database is being searched, and print a warning if a filter is being created but not used. 
4. Made translate_categorical_filters print of the translated filter, or explain why one was not generated. 
5. Call zoo library in params and add note explaining why it was required.
6. added error handling for translate_individual_filter